### PR TITLE
Add support for scoped packages

### DIFF
--- a/copy.mjs
+++ b/copy.mjs
@@ -21,7 +21,7 @@ export async function copy(packageName) {
       await mkdir(patchesPath, { recursive: true });
     }
 
-    await exec(`cp -R ${sourcePath} ${destPath}`);
+    await exec(`mkdir -p ${destPath} && cp -R ${sourcePath} ${destPath}`);
     console.log(`Package ${packageName} copied successfully.`);
   } catch (err) {
     console.error(`Error copying package ${packageName}:`, err);


### PR DESCRIPTION
This adds support for scoped packages such as `bunx patcheer copy @sanity/scheduled-publishing`, which currently fail because the intermediate scope directory `@sanity` doesn't exist.